### PR TITLE
Use the module with 'include' instead of 'extend'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+## build artifacts
 *.gem
+
+## environment normalisation
+/.bundle/
+/vendor/bundle

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A simple module to provide value objects semantics to a class.
 require 'value_object'
 
 class Point
-  extend ValueObject
+  include ValueObject
   fields :x, :y
 end
 
@@ -39,7 +39,7 @@ point.x = 3
 require 'value_object'
 
 class Point
-  extend ValueObject
+  include ValueObject
   fields :x, :y
 end
 
@@ -71,7 +71,7 @@ a_point.eql?(a_different_point)
 require 'value_object'
 
 class Point
-  extend ValueObject
+  include ValueObject
   fields :x, :y
 end
 
@@ -99,7 +99,7 @@ You can declare invariants to restrict field values on initialization
 require 'value_object'
 
 class Point
-  extend ValueObject
+  include ValueObject
   fields :x, :y
   invariants :x_less_than_y, :inside_first_quadrant
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -24,7 +24,7 @@ module ValueObject
   end
 
   class WrongNumberOfArguments < Exception
-    def initialize fields_number, arguments_number
+    def initialize(fields_number, arguments_number)
       super "Declared #{fields_number} fields but passing #{arguments_number}"
     end
   end

--- a/lib/value_object.rb
+++ b/lib/value_object.rb
@@ -1,89 +1,96 @@
 require 'exceptions'
 
 module ValueObject
-  def fields(*names)
-    raise NotDeclaredFields.new() if names.empty?()
 
-    attr_reader(*names)
-
-    define_method(:initialize) do |*values|
-      check_fields_are_initialized(values)
-      set_instance_variables(values)
-      check_invariants()
-    end
-
-    define_method(:eql?) do |other|
-      self.class == other.class && values == other.values
-    end
-
-    define_method(:==) do |other|
-      eql?(other)
-    end
-
-    define_method(:hash) do
-      self.class.hash ^ values.hash
-    end
-
-    define_method(:values) do
-      names.map { |field| send(field) }
-    end
-    protected(:values)
-
-    define_method(:check_invariants) do
-    end
-    private(:check_invariants)
-
-    define_method(:check_fields_are_initialized) do |values|
-      raise WrongNumberOfArguments.new(names.length, values.length) unless arguments_number_is_right?(values)
-      raise FieldWithoutValue.new(uninitialized_fields_names(values)) unless all_fields_initialized?(values)
-    end
-    private(:check_fields_are_initialized)
-
-    define_method(:arguments_number_is_right?) do |values|
-      fields_number = names.length
-      arguments_number = values.length
-      values.length == names.length
-    end
-    private(:arguments_number_is_right?)
-
-    define_method(:uninitialized_fields) do |values|
-      names.zip(values).select { |name, value| value.nil? }
-    end
-    private(:uninitialized_fields)
-
-    define_method(:all_fields_initialized?) do |values|
-      uninitialized_fields(values).empty?
-    end
-    private(:all_fields_initialized?)
-
-    define_method(:uninitialized_fields_names) do |values|
-      uninitialized_fields(values).map { |field| field.first }
-    end
-    private(:uninitialized_fields_names)
-
-    define_method(:set_instance_variables) do |values|
-      names.zip(values) do |name, value|
-        instance_variable_set(:"@#{name}", value)
-      end
-    end
-    private(:set_instance_variables)
+  def self.included(base)
+    base.extend(ClassMethods)
   end
 
-  def invariants(*predicate_symbols)
-    define_method(:check_invariants) do
-      predicate_symbols.each do |predicate_symbol|
-        valid = invariant_holds?(predicate_symbol)
-        raise ViolatedInvariant.new(predicate_symbol, self.values) unless valid
+  module ClassMethods
+    def fields(*names)
+      raise NotDeclaredFields.new() if names.empty?()
+
+      attr_reader(*names)
+
+      define_method(:initialize) do |*values|
+        check_fields_are_initialized(values)
+        set_instance_variables(values)
+        check_invariants()
       end
+
+      define_method(:eql?) do |other|
+        self.class == other.class && values == other.values
+      end
+
+      define_method(:==) do |other|
+        eql?(other)
+      end
+
+      define_method(:hash) do
+        self.class.hash ^ values.hash
+      end
+
+      define_method(:values) do
+        names.map { |field| send(field) }
+      end
+      protected(:values)
+
+      define_method(:check_invariants) do
+      end
+      private(:check_invariants)
+
+      define_method(:check_fields_are_initialized) do |values|
+        raise WrongNumberOfArguments.new(names.length, values.length) unless arguments_number_is_right?(values)
+        raise FieldWithoutValue.new(uninitialized_fields_names(values)) unless all_fields_initialized?(values)
+      end
+      private(:check_fields_are_initialized)
+
+      define_method(:arguments_number_is_right?) do |values|
+        fields_number = names.length
+        arguments_number = values.length
+        values.length == names.length
+      end
+      private(:arguments_number_is_right?)
+
+      define_method(:uninitialized_fields) do |values|
+        names.zip(values).select { |name, value| value.nil? }
+      end
+      private(:uninitialized_fields)
+
+      define_method(:all_fields_initialized?) do |values|
+        uninitialized_fields(values).empty?
+      end
+      private(:all_fields_initialized?)
+
+      define_method(:uninitialized_fields_names) do |values|
+        uninitialized_fields(values).map { |field| field.first }
+      end
+      private(:uninitialized_fields_names)
+
+      define_method(:set_instance_variables) do |values|
+        names.zip(values) do |name, value|
+          instance_variable_set(:"@#{name}", value)
+        end
+      end
+      private(:set_instance_variables)
     end
 
-    define_method(:invariant_holds?) do |predicate_symbol|
-      begin
-        valid = send(predicate_symbol)
-      rescue
-        raise NotImplementedInvariant.new(predicate_symbol)
+    def invariants(*predicate_symbols)
+      define_method(:check_invariants) do
+        predicate_symbols.each do |predicate_symbol|
+          valid = invariant_holds?(predicate_symbol)
+          raise ViolatedInvariant.new(predicate_symbol, self.values) unless valid
+        end
       end
+
+      define_method(:invariant_holds?) do |predicate_symbol|
+        begin
+          valid = send(predicate_symbol)
+        rescue
+          raise NotImplementedInvariant.new(predicate_symbol)
+        end
+      end
+      private(:invariant_holds?)
     end
-    private(:invariant_holds?)
   end
 end

--- a/lib/value_object.rb
+++ b/lib/value_object.rb
@@ -6,91 +6,103 @@ module ValueObject
     base.extend(ClassMethods)
   end
 
+  def initialize(*values)
+    @values = values
+    check_fields_are_initialized
+    set_instance_variables
+    check_invariants
+  end
+
+  def eql?(other)
+    self.class == other.class && values == other.values
+  end
+
+  def ==(other)
+    eql?(other)
+  end
+
+  def hash
+    self.class.hash ^ values.hash
+  end
+
+  protected
+
+  def values
+    @values
+  end
+
+  private
+
+  def names
+    self.class.field_names
+  end
+
+  def predicates
+    self.class.predicate_symbols
+  end
+
+  def check_fields_are_initialized
+    raise WrongNumberOfArguments.new(names.length, values.length) unless arguments_number_is_right?
+    raise FieldWithoutValue.new(uninitialized_field_names) unless all_fields_initialized?
+  end
+
+  def set_instance_variables
+    names.zip(values) do |name, value|
+      instance_variable_set(:"@#{name}", value)
+    end
+  end
+
+  def arguments_number_is_right?
+    values.length == names.length
+  end
+
+  def uninitialized_fields
+    names.zip(values).select { |name, value| value.nil? }
+  end
+
+  def all_fields_initialized?
+    uninitialized_fields.empty?
+  end
+
+  def uninitialized_field_names
+    uninitialized_fields.map { |field| field.first }
+  end
+
+  def check_invariants
+    return if predicates.nil?
+
+    predicates.each do |predicate|
+      valid = invariant_holds?(predicate)
+      raise ViolatedInvariant.new(predicate, values) unless valid
+    end
+  end
+
+  def invariant_holds?(predicate_symbol)
+    begin
+      valid = send(predicate_symbol)
+    rescue
+      raise NotImplementedInvariant.new(predicate_symbol)
+    end
+  end
+
   module ClassMethods
+    def field_names
+      @field_names
+    end
+
+    def predicate_symbols
+      @predicate_symbols
+    end
+
     def fields(*names)
-      raise NotDeclaredFields.new() if names.empty?()
+      raise NotDeclaredFields.new if names.empty?
 
       attr_reader(*names)
-
-      define_method(:initialize) do |*values|
-        check_fields_are_initialized(values)
-        set_instance_variables(values)
-        check_invariants()
-      end
-
-      define_method(:eql?) do |other|
-        self.class == other.class && values == other.values
-      end
-
-      define_method(:==) do |other|
-        eql?(other)
-      end
-
-      define_method(:hash) do
-        self.class.hash ^ values.hash
-      end
-
-      define_method(:values) do
-        names.map { |field| send(field) }
-      end
-      protected(:values)
-
-      define_method(:check_invariants) do
-      end
-      private(:check_invariants)
-
-      define_method(:check_fields_are_initialized) do |values|
-        raise WrongNumberOfArguments.new(names.length, values.length) unless arguments_number_is_right?(values)
-        raise FieldWithoutValue.new(uninitialized_fields_names(values)) unless all_fields_initialized?(values)
-      end
-      private(:check_fields_are_initialized)
-
-      define_method(:arguments_number_is_right?) do |values|
-        fields_number = names.length
-        arguments_number = values.length
-        values.length == names.length
-      end
-      private(:arguments_number_is_right?)
-
-      define_method(:uninitialized_fields) do |values|
-        names.zip(values).select { |name, value| value.nil? }
-      end
-      private(:uninitialized_fields)
-
-      define_method(:all_fields_initialized?) do |values|
-        uninitialized_fields(values).empty?
-      end
-      private(:all_fields_initialized?)
-
-      define_method(:uninitialized_fields_names) do |values|
-        uninitialized_fields(values).map { |field| field.first }
-      end
-      private(:uninitialized_fields_names)
-
-      define_method(:set_instance_variables) do |values|
-        names.zip(values) do |name, value|
-          instance_variable_set(:"@#{name}", value)
-        end
-      end
-      private(:set_instance_variables)
+      @field_names = names
     end
 
     def invariants(*predicate_symbols)
-      define_method(:check_invariants) do
-        predicate_symbols.each do |predicate_symbol|
-          valid = invariant_holds?(predicate_symbol)
-          raise ViolatedInvariant.new(predicate_symbol, self.values) unless valid
-        end
-      end
-
-      define_method(:invariant_holds?) do |predicate_symbol|
-        begin
-          valid = send(predicate_symbol)
-        rescue
-          raise NotImplementedInvariant.new(predicate_symbol)
-        end
-      end
-      private(:invariant_holds?)
+      @predicate_symbols = predicate_symbols
     end
   end
 end

--- a/spec/value_object_spec.rb
+++ b/spec/value_object_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "./lib/value_object"
+require './lib/value_object'
 
 describe "ValueObject" do
 
@@ -38,40 +38,41 @@ describe "ValueObject" do
   describe "restrictions" do
     describe "on declaration" do
       it "must at least have one field" do
-        expect do
-          class DummyWithNoFieldsUsingFieldsMethod
-            extend ValueObject
+        expect {
+          class Point
+            include ValueObject
             fields
           end
-        end.to raise_error(ValueObject::NotDeclaredFields)
+        }.to raise_error(ValueObject::NotDeclaredFields)
       end
     end
 
     describe "on initialization" do
       it "must not have any field initialized to nil" do
-        class DummyWithDeclaredFieldsWithoutValue
-          extend ValueObject
+        class Point
+          include ValueObject
           fields :x, :y
         end
 
-        expect{
-          DummyWithDeclaredFieldsWithoutValue.new 1, nil
-          }.to raise_error(ValueObject::FieldWithoutValue, "Declared fields [:y] must have value")
-        
+        expect {
+          Point.new 1, nil
+        }.to raise_error(ValueObject::FieldWithoutValue, "Declared fields [:y] must have value")
+
       end
-      
+
       it "must have number of values equal to number of fields" do
         class Point
           extend ValueObject
           fields :x, :y
         end
- 
-        expect{
-          Point.new(1)
-          }.to raise_error(ValueObject::WrongNumberOfArguments)
-        
 
-        expect{ Point.new(1, 2, 3) }.to raise_error(ValueObject::WrongNumberOfArguments, "Declared 2 fields but passing 3")
+        expect {
+          Point.new(1)
+        }.to raise_error(ValueObject::WrongNumberOfArguments)
+
+        expect {
+          Point.new(1, 2, 3) 
+        }.to raise_error(ValueObject::WrongNumberOfArguments, "Declared 2 fields but passing 3")
       end
     end
   end
@@ -84,34 +85,34 @@ describe "ValueObject" do
         invariants :x_less_than_y, :inside_first_quadrant
 
         private
-        def inside_first_quadrant
-          x > 0 && y > 0
-        end
-
         def x_less_than_y
           x < y
         end
+
+        def inside_first_quadrant
+          x > 0 && y > 0
+        end
       end
 
-      expect{ Point.new(-5, 3) }.to raise_error(
-        ValueObject::ViolatedInvariant, "Fields values [-5, 3] violate invariant: inside_first_quadrant"
-      )
+      expect {
+        Point.new(6, 3)
+      }.to raise_error(ValueObject::ViolatedInvariant, "Fields values [6, 3] violate invariant: x_less_than_y")
 
-      expect{ Point.new(6, 3) }.to raise_error(
-        ValueObject::ViolatedInvariant, "Fields values [6, 3] violate invariant: x_less_than_y"
-      )
+      expect {
+        Point.new(-5, 3)
+      }.to raise_error(ValueObject::ViolatedInvariant, "Fields values [-5, 3] violate invariant: inside_first_quadrant")
     end
 
     it "raises an exception when a declared invariant has not been implemented" do
-      class PairOfIntegers
-        extend ValueObject
+      class Point
+        include ValueObject
         fields :x, :y
         invariants :integers
       end
 
-      expect{ PairOfIntegers.new(5, 2) }.to raise_error(
-        ValueObject::NotImplementedInvariant, "Invariant integers needs to be implemented"
-      )
+      expect {
+        Point.new(5, 2)
+      }.to raise_error(ValueObject::NotImplementedInvariant, "Invariant integers needs to be implemented")
     end
   end
 end

--- a/spec/value_object_spec.rb
+++ b/spec/value_object_spec.rb
@@ -5,7 +5,7 @@ describe "ValueObject" do
 
   describe "standard behavior" do
     class Point
-      extend ValueObject
+      include ValueObject
       fields :x, :y
     end
 
@@ -62,7 +62,7 @@ describe "ValueObject" do
 
       it "must have number of values equal to number of fields" do
         class Point
-          extend ValueObject
+          include ValueObject
           fields :x, :y
         end
 
@@ -80,7 +80,7 @@ describe "ValueObject" do
   describe "forcing invariants" do
     it "forces declared invariants" do
       class Point
-        extend ValueObject
+        include ValueObject
         fields :x, :y
         invariants :x_less_than_y, :inside_first_quadrant
 


### PR DESCRIPTION
As the module is providing instance methods to the including class, the 'include' semantics would seem more appropriate. By doing that, also, the instance methods could be defined in the module body and metaprogramming wouldn't be necessary (except for the field attributes).

Open for discussion!
