### PR TITLE
Include support for the definition of implicit invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,33 @@ a_point.hash == a_different_point.hash
 
 ### Invariants
 
-You can declare invariants to restrict field values on initialization
+You can declare invariants to restrict field values on initialization,
+both in an implicit or explicit way:
+
+#### Implicit definition
+
+```ruby
+require 'value_object'
+
+class Point
+  include ValueObject
+  fields :x, :y
+  invariants do
+    x < y
+  end
+end
+
+Point.new(-5, 3)
+# ValueObject::ViolatedInvariant: Fields values [-5, 3] violate invariant: implicit
+
+Point.new(6, 3)
+# ValueObject::ViolatedInvariant: Fields values [6, 3] violate invariant: implicit
+
+Point.new(1, 3)
+# => #<Point:0x894aacc @x=1, @y=3>
+```
+
+#### Explicit definition
 
 ```ruby
 require 'value_object'

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,4 +1,10 @@
 module ValueObject
+  class BadInvariantDefinition < Exception
+    def initialize()
+      super "Invariant must be either declared or specified"
+    end
+  end
+
   class NotImplementedInvariant < Exception
     def initialize(name)
       super "Invariant #{name} needs to be implemented"
@@ -7,7 +13,7 @@ module ValueObject
 
   class ViolatedInvariant < Exception
     def initialize(name, wrong_values)
-      super "Fields values " + wrong_values.to_s + " violate invariant: #{name}"
+      super "Field values " + wrong_values.to_s + " violate invariant: #{name}"
     end
   end
 


### PR DESCRIPTION
It occurred to me that in some cases it would be nice if the invariants could also be declared inline, as a block (the return value of the block will determine if the invariant holds or not).

I'm calling the existing mechanism 'explicit' (a method is declared) and I'm calling the new one 'implicit' (the invariants are written in a block, no method declaration needed).

I've kept both alternatives mutually exclusive to avoid precedence problems.
